### PR TITLE
fix highlight left menu for DCS modules

### DIFF
--- a/CHANGELOG_103.md
+++ b/CHANGELOG_103.md
@@ -1,0 +1,1 @@
+* FIX admin - surbrillance dans le menu de gauche pour les modules

--- a/templates/admin/module/edit.html.twig
+++ b/templates/admin/module/edit.html.twig
@@ -1,6 +1,6 @@
 {% extends 'admin/layout.html.twig' %}
 {% set libKilikTable=true %}
-{% set section="admin" %}
+{% set section="dcs" %}
 {% set subSection="module" %}
 
 {% block pageContent %}

--- a/templates/admin/module/list.html.twig
+++ b/templates/admin/module/list.html.twig
@@ -1,6 +1,6 @@
 {% extends 'admin/layout.html.twig' %}
 {% set libKilikTable=true %}
-{% set section="admin" %}
+{% set section="dcs" %}
 {% set subSection="module" %}
 
 {% block pageContent %}

--- a/templates/admin/module/view.html.twig
+++ b/templates/admin/module/view.html.twig
@@ -1,6 +1,6 @@
 {% extends 'admin/layout.html.twig' %}
 {% set libKilikTable=true %}
-{% set section="admin" %}
+{% set section="dcs" %}
 {% set subSection="module" %}
 
 {% block pageContent %}


### PR DESCRIPTION
close #103 