### PR TITLE
remove EC05 mention

### DIFF
--- a/CHANGELOG_377.md
+++ b/CHANGELOG_377.md
@@ -1,0 +1,1 @@
+- UPDATED Replaced Falcon BMS EC05 link with BMS image on homepage

--- a/templates/website/veaf/default/index.html.twig
+++ b/templates/website/veaf/default/index.html.twig
@@ -99,11 +99,7 @@
     <div class="container container-main pt-3 pb-3 mb-3">
         <div class="row mb-4">
             <div class="col-lg-12">
-                <p>
-                    Pour les vols sur <b>Falcon BMS</b>, nous vous conseillons de rejoindre l'EC05, qui comprend les
-                    meilleurs pilotes et instructeurs du domaine (normal, ils viennent de la VEAF ^^)
-                </p>
-                <a href="http://ec05.fr/EC05/"><img src="{{ cdn_url }}/img/ec05_logo.png" class="embed-responsive"></a>
+                <img src="{{ cdn_url }}/img/bms.png" class="embed-responsive">
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary by Sourcery

Update the homepage Falcon BMS section to remove the EC05 reference and reflect the new presentation.

Enhancements:
- Replace the Falcon BMS EC05 promotional text and external link with a standalone BMS image on the homepage.

Documentation:
- Add a changelog entry documenting the replacement of the Falcon BMS EC05 link with a BMS image on the homepage.