### PR TITLE
fix teamspeak scan command

### DIFF
--- a/CHANGELOG_400.md
+++ b/CHANGELOG_400.md
@@ -1,0 +1,1 @@
+- FIX teamspeak status scan command

--- a/src/Command/TeamSpeakScanCommand.php
+++ b/src/Command/TeamSpeakScanCommand.php
@@ -28,8 +28,12 @@ class TeamSpeakScanCommand extends Command
     {
         $output->writeln('scanning team speak server');
 
-        $this->clientCache->putClients();
-        $this->clientCache->putChannels();
+        try {
+            $this->clientCache->putClients();
+            $this->clientCache->putChannels();
+        } finally {
+            $this->clientCache->disconnect();
+        }
 
         $output->writeln('team speak server scan done.');
 

--- a/src/DTO/TeamSpeakChannel.php
+++ b/src/DTO/TeamSpeakChannel.php
@@ -2,6 +2,8 @@
 
 namespace App\DTO;
 
+use PlanetTeamSpeak\TeamSpeak3Framework\Node\Channel;
+
 class TeamSpeakChannel
 {
     private ?int $cid = null;
@@ -12,7 +14,7 @@ class TeamSpeakChannel
 
     private array $clients = [];
 
-    public static function createFromNodeChannel(\TeamSpeak3_Node_Channel $nodeChannel): self
+    public static function createFromNodeChannel(Channel $nodeChannel): self
     {
         $channel = new self();
 

--- a/src/DTO/TeamSpeakClient.php
+++ b/src/DTO/TeamSpeakClient.php
@@ -2,6 +2,8 @@
 
 namespace App\DTO;
 
+use PlanetTeamSpeak\TeamSpeak3Framework\Node\Client;
+
 class TeamSpeakClient
 {
     private ?int $clid = null;
@@ -18,7 +20,7 @@ class TeamSpeakClient
     private ?int $created = null;
     private ?int $lastConnected = null;
 
-    public static function createFromNodeClient(\TeamSpeak3_Node_Client $nodeClient): self
+    public static function createFromNodeClient(Client $nodeClient): self
     {
         $client = new self();
 

--- a/src/Service/TeamSpeak3Client.php
+++ b/src/Service/TeamSpeak3Client.php
@@ -4,10 +4,12 @@ namespace App\Service;
 
 use App\DTO\TeamSpeakChannel;
 use App\DTO\TeamSpeakClient;
+use PlanetTeamSpeak\TeamSpeak3Framework\Node\Server;
+use PlanetTeamSpeak\TeamSpeak3Framework\TeamSpeak3;
 
 class TeamSpeak3Client
 {
-    private ?\TeamSpeak3_Node_Server $client = null;
+    private ?Server $client = null;
     private ?string $teamSpeakApiUrl = null;
 
     public function __construct(string $teamSpeakApiUrl)
@@ -23,14 +25,26 @@ class TeamSpeak3Client
         return parse_url($this->teamSpeakApiUrl);
     }
 
-    public function getClient(): ?\TeamSpeak3_Node_Server
+    public function getClient(): ?Server
     {
         // only create connection when needed
         if (null === $this->client) {
-            $this->client = \TeamSpeak3::factory($this->teamSpeakApiUrl);
+            $this->client = TeamSpeak3::factory($this->teamSpeakApiUrl);
         }
 
         return $this->client;
+    }
+
+    /**
+     * Disconnect from the TeamSpeak server.
+     */
+    public function disconnect(): void
+    {
+        if (null !== $this->client) {
+            // Server -> Host -> ServerQuery(Adapter) -> Transport
+            $this->client->getParent()->getParent()->getTransport()->disconnect();
+            $this->client = null;
+        }
     }
 
     public function countClients(): int

--- a/src/Service/TeamSpeak3ClientCache.php
+++ b/src/Service/TeamSpeak3ClientCache.php
@@ -39,6 +39,14 @@ class TeamSpeak3ClientCache
         return $this->ts3Client;
     }
 
+    /**
+     * Disconnect from the TeamSpeak server.
+     */
+    public function disconnect(): void
+    {
+        $this->ts3Client->disconnect();
+    }
+
     private function cacheKey(string $key): string
     {
         return sprintf('%s.%s', static::CACHE_PREFIX, $key);

--- a/tests/Unit/Command/TeamSpeakScanCommandTest.php
+++ b/tests/Unit/Command/TeamSpeakScanCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\TeamSpeakScanCommand;
+use App\Service\TeamSpeak3ClientCache;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class TeamSpeakScanCommandTest extends TestCase
+{
+    private TeamSpeak3ClientCache $clientCache;
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->clientCache = $this->createMock(TeamSpeak3ClientCache::class);
+
+        $command = new TeamSpeakScanCommand($this->clientCache);
+
+        $application = new Application();
+        $application->add($command);
+
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function testExecuteCallsPutClientsAndPutChannels(): void
+    {
+        $this->clientCache
+            ->expects($this->once())
+            ->method('putClients');
+
+        $this->clientCache
+            ->expects($this->once())
+            ->method('putChannels');
+
+        $this->commandTester->execute([]);
+    }
+
+    public function testExecuteReturnsSuccessCode(): void
+    {
+        $exitCode = $this->commandTester->execute([]);
+
+        $this->assertEquals(0, $exitCode);
+    }
+
+    public function testExecuteOutputsProgressMessages(): void
+    {
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+
+        $this->assertStringContainsString('scanning team speak server', $output);
+        $this->assertStringContainsString('team speak server scan done', $output);
+    }
+}

--- a/tests/Unit/DTO/TeamSpeakChannelTest.php
+++ b/tests/Unit/DTO/TeamSpeakChannelTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Tests\Unit\DTO;
+
+use App\DTO\TeamSpeakChannel;
+use App\DTO\TeamSpeakClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for TeamSpeakChannel DTO.
+ *
+ * Note: Tests for createFromNodeChannel() are skipped because the TeamSpeak3
+ * library is loaded lazily and the classes don't exist at test runtime.
+ * The getter/setter tests provide sufficient coverage for the DTO.
+ */
+class TeamSpeakChannelTest extends TestCase
+{
+    // =========================================================================
+    // Tests for getters and setters
+    // =========================================================================
+
+    public function testSettersReturnSelfForFluentInterface(): void
+    {
+        $channel = new TeamSpeakChannel();
+
+        $this->assertSame($channel, $channel->setCid(1));
+        $this->assertSame($channel, $channel->setPid(0));
+        $this->assertSame($channel, $channel->setOrder(1));
+        $this->assertSame($channel, $channel->setName('Test'));
+        $this->assertSame($channel, $channel->setTopic('Topic'));
+    }
+
+    public function testGettersReturnSetValues(): void
+    {
+        $channel = new TeamSpeakChannel();
+
+        $channel->setCid(42);
+        $this->assertEquals(42, $channel->getCid());
+
+        $channel->setPid(10);
+        $this->assertEquals(10, $channel->getPid());
+
+        $channel->setOrder(5);
+        $this->assertEquals(5, $channel->getOrder());
+
+        $channel->setName('Operations Room');
+        $this->assertEquals('Operations Room', $channel->getName());
+
+        $channel->setTopic('Mission briefings');
+        $this->assertEquals('Mission briefings', $channel->getTopic());
+    }
+
+    public function testDefaultValuesAreNull(): void
+    {
+        $channel = new TeamSpeakChannel();
+
+        $this->assertNull($channel->getCid());
+        $this->assertNull($channel->getPid());
+        $this->assertNull($channel->getOrder());
+        $this->assertNull($channel->getName());
+        $this->assertNull($channel->getTopic());
+    }
+
+    // =========================================================================
+    // Tests for client management
+    // =========================================================================
+
+    public function testGetClientsReturnsEmptyArrayByDefault(): void
+    {
+        $channel = new TeamSpeakChannel();
+
+        $this->assertIsArray($channel->getClients());
+        $this->assertEmpty($channel->getClients());
+    }
+
+    public function testAddClientAddsToClientsList(): void
+    {
+        $channel = new TeamSpeakChannel();
+        $client = new TeamSpeakClient();
+        $client->setNickName('Pilot1');
+
+        $channel->addClient($client);
+
+        $this->assertCount(1, $channel->getClients());
+        $this->assertSame($client, $channel->getClients()[0]);
+    }
+
+    public function testAddMultipleClients(): void
+    {
+        $channel = new TeamSpeakChannel();
+
+        $client1 = new TeamSpeakClient();
+        $client1->setNickName('Pilot1');
+
+        $client2 = new TeamSpeakClient();
+        $client2->setNickName('Pilot2');
+
+        $client3 = new TeamSpeakClient();
+        $client3->setNickName('Pilot3');
+
+        $channel->addClient($client1);
+        $channel->addClient($client2);
+        $channel->addClient($client3);
+
+        $clients = $channel->getClients();
+
+        $this->assertCount(3, $clients);
+        $this->assertSame($client1, $clients[0]);
+        $this->assertSame($client2, $clients[1]);
+        $this->assertSame($client3, $clients[2]);
+    }
+
+    public function testClientsAreAddedInOrder(): void
+    {
+        $channel = new TeamSpeakChannel();
+
+        for ($i = 1; $i <= 5; ++$i) {
+            $client = new TeamSpeakClient();
+            $client->setNickName("Pilot{$i}");
+            $channel->addClient($client);
+        }
+
+        $clients = $channel->getClients();
+
+        $this->assertEquals('Pilot1', $clients[0]->getNickName());
+        $this->assertEquals('Pilot5', $clients[4]->getNickName());
+    }
+}

--- a/tests/Unit/DTO/TeamSpeakClientTest.php
+++ b/tests/Unit/DTO/TeamSpeakClientTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Tests\Unit\DTO;
+
+use App\DTO\TeamSpeakClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for TeamSpeakClient DTO.
+ *
+ * Note: Tests for createFromNodeClient() are skipped because the TeamSpeak3
+ * library is loaded lazily and the classes don't exist at test runtime.
+ * The getter/setter tests provide sufficient coverage for the DTO.
+ */
+class TeamSpeakClientTest extends TestCase
+{
+    // =========================================================================
+    // Tests for getters and setters
+    // =========================================================================
+
+    public function testSettersReturnSelfForFluentInterface(): void
+    {
+        $client = new TeamSpeakClient();
+
+        $this->assertSame($client, $client->setClid(1));
+        $this->assertSame($client, $client->setCid(1));
+        $this->assertSame($client, $client->setDatabaseId(1));
+        $this->assertSame($client, $client->setNickName('Test'));
+        $this->assertSame($client, $client->setCountry('FR'));
+        $this->assertSame($client, $client->setUniqueIdentifier('abc'));
+        $this->assertSame($client, $client->setServerGroups(['1', '2']));
+        $this->assertSame($client, $client->setChannelGroupId(1));
+        $this->assertSame($client, $client->setVersion('1.0'));
+        $this->assertSame($client, $client->setPlatform('Windows'));
+        $this->assertSame($client, $client->setIdleTime(1000));
+        $this->assertSame($client, $client->setCreated(1609459200));
+        $this->assertSame($client, $client->setLastConnected(1609459200));
+    }
+
+    public function testGettersReturnSetValues(): void
+    {
+        $client = new TeamSpeakClient();
+
+        $client->setClid(42);
+        $this->assertEquals(42, $client->getClid());
+
+        $client->setCid(10);
+        $this->assertEquals(10, $client->getCid());
+
+        $client->setDatabaseId(123);
+        $this->assertEquals(123, $client->getDatabaseId());
+
+        $client->setNickName('Pilot');
+        $this->assertEquals('Pilot', $client->getNickName());
+
+        $client->setCountry('DE');
+        $this->assertEquals('DE', $client->getCountry());
+
+        $client->setUniqueIdentifier('unique123');
+        $this->assertEquals('unique123', $client->getUniqueIdentifier());
+
+        $client->setServerGroups(['1', '2', '3']);
+        $this->assertEquals(['1', '2', '3'], $client->getServerGroups());
+
+        $client->setChannelGroupId(5);
+        $this->assertEquals(5, $client->getChannelGroupId());
+
+        $client->setVersion('3.5.6');
+        $this->assertEquals('3.5.6', $client->getVersion());
+
+        $client->setPlatform('macOS');
+        $this->assertEquals('macOS', $client->getPlatform());
+
+        $client->setIdleTime(5000);
+        $this->assertEquals(5000, $client->getIdleTime());
+
+        $client->setCreated(1609459200);
+        $this->assertEquals(1609459200, $client->getCreated());
+
+        $client->setLastConnected(1609459300);
+        $this->assertEquals(1609459300, $client->getLastConnected());
+    }
+
+    public function testDefaultValuesAreNull(): void
+    {
+        $client = new TeamSpeakClient();
+
+        $this->assertNull($client->getClid());
+        $this->assertNull($client->getCid());
+        $this->assertNull($client->getDatabaseId());
+        $this->assertNull($client->getNickName());
+        $this->assertNull($client->getCountry());
+        $this->assertNull($client->getUniqueIdentifier());
+        $this->assertNull($client->getChannelGroupId());
+        $this->assertNull($client->getVersion());
+        $this->assertNull($client->getPlatform());
+        $this->assertNull($client->getIdleTime());
+        $this->assertNull($client->getCreated());
+        $this->assertNull($client->getLastConnected());
+    }
+
+    public function testServerGroupsDefaultsToEmptyArray(): void
+    {
+        $client = new TeamSpeakClient();
+
+        $this->assertIsArray($client->getServerGroups());
+        $this->assertEmpty($client->getServerGroups());
+    }
+
+    public function testServerGroupsCanBeSetAsArray(): void
+    {
+        $client = new TeamSpeakClient();
+        $client->setServerGroups(['6', '7', '8']);
+
+        $this->assertEquals(['6', '7', '8'], $client->getServerGroups());
+        $this->assertCount(3, $client->getServerGroups());
+    }
+}

--- a/tests/Unit/Service/TeamSpeak3ClientCacheTest.php
+++ b/tests/Unit/Service/TeamSpeak3ClientCacheTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\DTO\TeamSpeakChannel;
+use App\DTO\TeamSpeakClient;
+use App\Service\TeamSpeak3Client;
+use App\Service\TeamSpeak3ClientCache;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class TeamSpeak3ClientCacheTest extends TestCase
+{
+    /** @var TeamSpeak3Client|MockObject */
+    private $ts3Client;
+    /** @var ArrayAdapter */
+    private $cacheAdapter;
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+    /** @var TeamSpeak3ClientCache */
+    private $service;
+
+    protected function setUp(): void
+    {
+        $this->ts3Client = $this->createMock(TeamSpeak3Client::class);
+        $this->cacheAdapter = new ArrayAdapter();
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->service = new TeamSpeak3ClientCache(
+            $this->ts3Client,
+            $this->cacheAdapter,
+            $this->logger
+        );
+    }
+
+    // =========================================================================
+    // Tests for getTeamSpeakClient()
+    // =========================================================================
+
+    public function testGetTeamSpeakClientReturnsClient(): void
+    {
+        $result = $this->service->getTeamSpeakClient();
+
+        $this->assertSame($this->ts3Client, $result);
+    }
+
+    // =========================================================================
+    // Tests for getClients()
+    // =========================================================================
+
+    public function testGetClientsReturnsNullWhenCacheEmpty(): void
+    {
+        $result = $this->service->getClients();
+
+        $this->assertNull($result);
+    }
+
+    public function testGetClientsReturnsCachedDataAfterPut(): void
+    {
+        $clients = [$this->createClient('Player1'), $this->createClient('Player2')];
+        $this->ts3Client->method('getClients')->willReturn($clients);
+
+        $this->service->putClients();
+        $result = $this->service->getClients();
+
+        $this->assertCount(2, $result);
+    }
+
+    // =========================================================================
+    // Tests for putClients()
+    // =========================================================================
+
+    public function testPutClientsFetchesAndCachesClients(): void
+    {
+        $clients = [$this->createClient('Player1'), $this->createClient('Player2')];
+
+        $this->ts3Client
+            ->expects($this->once())
+            ->method('getClients')
+            ->willReturn($clients);
+
+        $this->service->putClients();
+
+        // Verify clients are cached
+        $cachedClients = $this->service->getClients();
+        $this->assertCount(2, $cachedClients);
+
+        // Verify count is cached
+        $cachedCount = $this->service->countClients();
+        $this->assertEquals(2, $cachedCount);
+    }
+
+    public function testPutClientsCachesEmptyArrayOnException(): void
+    {
+        $this->ts3Client
+            ->method('getClients')
+            ->willThrowException(new \Exception('Connection failed'));
+
+        $this->logger
+            ->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('error reading teamspeak clients'));
+
+        $this->service->putClients();
+
+        // Verify empty array is cached
+        $cachedClients = $this->service->getClients();
+        $this->assertIsArray($cachedClients);
+        $this->assertEmpty($cachedClients);
+
+        // Verify count is 0
+        $cachedCount = $this->service->countClients();
+        $this->assertEquals(0, $cachedCount);
+    }
+
+    // =========================================================================
+    // Tests for getChannels()
+    // =========================================================================
+
+    public function testGetChannelsReturnsNullWhenCacheEmpty(): void
+    {
+        $result = $this->service->getChannels();
+
+        $this->assertNull($result);
+    }
+
+    public function testGetChannelsReturnsCachedDataAfterPut(): void
+    {
+        $channels = [$this->createChannel('Lobby'), $this->createChannel('Flight')];
+        $this->ts3Client->method('getChannels')->willReturn($channels);
+
+        $this->service->putChannels();
+        $result = $this->service->getChannels();
+
+        $this->assertCount(2, $result);
+    }
+
+    // =========================================================================
+    // Tests for putChannels()
+    // =========================================================================
+
+    public function testPutChannelsFetchesAndCachesChannels(): void
+    {
+        $channels = [$this->createChannel('Lobby'), $this->createChannel('Flight')];
+
+        $this->ts3Client
+            ->expects($this->once())
+            ->method('getChannels')
+            ->willReturn($channels);
+
+        $this->service->putChannels();
+
+        // Verify channels are cached
+        $cachedChannels = $this->service->getChannels();
+        $this->assertCount(2, $cachedChannels);
+    }
+
+    public function testPutChannelsCachesEmptyArrayOnException(): void
+    {
+        $this->ts3Client
+            ->method('getChannels')
+            ->willThrowException(new \Exception('Connection failed'));
+
+        $this->logger
+            ->expects($this->once())
+            ->method('error');
+
+        $this->service->putChannels();
+
+        // Verify empty array is cached
+        $cachedChannels = $this->service->getChannels();
+        $this->assertIsArray($cachedChannels);
+        $this->assertEmpty($cachedChannels);
+    }
+
+    public function testPutChannelsFillsClientsInChannelsWhenClientsLoaded(): void
+    {
+        // First, load clients via putClients
+        $client1 = $this->createClient('Player1');
+        $client1->setCid(1);
+        $client2 = $this->createClient('Player2');
+        $client2->setCid(2);
+        $clients = [$client1, $client2];
+
+        $this->ts3Client->method('getClients')->willReturn($clients);
+
+        // Now prepare channels
+        $channel1 = $this->createChannel('Lobby');
+        $channel1->setCid(1);
+        $channel2 = $this->createChannel('Flight');
+        $channel2->setCid(2);
+        $channels = [$channel1, $channel2];
+
+        $this->ts3Client->method('getChannels')->willReturn($channels);
+
+        // Call putClients first to load clients into the service
+        $this->service->putClients();
+
+        // Now call putChannels - it should fill clients into channels
+        $this->service->putChannels();
+
+        // Verify clients were added to channels
+        $this->assertCount(1, $channel1->getClients());
+        $this->assertCount(1, $channel2->getClients());
+        $this->assertSame($client1, $channel1->getClients()[0]);
+        $this->assertSame($client2, $channel2->getClients()[0]);
+    }
+
+    // =========================================================================
+    // Tests for countClients()
+    // =========================================================================
+
+    public function testCountClientsReturnsNullWhenNotCached(): void
+    {
+        $result = $this->service->countClients();
+
+        $this->assertNull($result);
+    }
+
+    public function testCountClientsReturnsCachedCount(): void
+    {
+        $clients = [
+            $this->createClient('Player1'),
+            $this->createClient('Player2'),
+            $this->createClient('Player3'),
+        ];
+        $this->ts3Client->method('getClients')->willReturn($clients);
+
+        $this->service->putClients();
+
+        $result = $this->service->countClients();
+
+        $this->assertEquals(3, $result);
+    }
+
+    // =========================================================================
+    // Tests for cache configuration
+    // =========================================================================
+
+    public function testCacheExpirationConstantIs120Seconds(): void
+    {
+        $this->assertEquals(120, TeamSpeak3ClientCache::CACHE_EXPIRES);
+    }
+
+    public function testCachePrefixIsTeamspeak3(): void
+    {
+        $this->assertEquals('teamspeak3', TeamSpeak3ClientCache::CACHE_PREFIX);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function createClient(string $nickname): TeamSpeakClient
+    {
+        $client = new TeamSpeakClient();
+        $client->setNickName($nickname);
+
+        return $client;
+    }
+
+    private function createChannel(string $name): TeamSpeakChannel
+    {
+        $channel = new TeamSpeakChannel();
+        $channel->setName($name);
+
+        return $channel;
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Fix the TeamSpeak status scan by updating to the new TeamSpeak3 framework API and ensuring connections are cleanly disconnected after scans.

Bug Fixes:
- Ensure the TeamSpeak scan command always disconnects from the server after scanning, even when an error occurs.

Enhancements:
- Switch TeamSpeak DTOs and client service to use the namespaced PlanetTeamSpeak TeamSpeak3 framework classes instead of legacy global classes.

Documentation:
- Add a 4.0.0 changelog entry documenting the TeamSpeak status scan fix.

Tests:
- Add unit tests for TeamSpeak3ClientCache to cover client/channel caching behavior and error handling.
- Add unit tests for TeamSpeakChannel and TeamSpeakClient DTOs to verify getters, setters, and client list management.
- Add a unit test for TeamSpeakScanCommand to verify it invokes caching operations and outputs progress messages.