### PR TITLE
import player stats from dcsbotserver tables

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -26,6 +26,12 @@ APP_SECRET=138768954d0427c7c372bcf29b1148c9
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data_%kernel.environment%.db"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4"
 DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+
+# Perun database (MySQL) - DCS World statistics from Perun mod
+DATABASE_PERUN_URL="mysql://user:password@127.0.0.1:3306/perun?serverVersion=5.7&charset=utf8mb4"
+
+# DCS Bot database (PostgreSQL) - DCS World statistics from DCSServerBot
+DATABASE_DCSBOT_URL="postgresql://user:password@127.0.0.1:5432/dcs_bot?serverVersion=15&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/mailer ###

--- a/.php.env.dist
+++ b/.php.env.dist
@@ -2,6 +2,9 @@
 APP_SECRET=0123456789
 DATABASE_PERUN_URL=mysql://root:test@mysql:3306/website?serverVersion=5.7
 
+# DCS Bot database (PostgreSQL) - DCS World statistics from DCSServerBot
+DATABASE_DCSBOT_URL="postgresql://user:password@127.0.0.1:5432/dcs_bot?serverVersion=15&charset=utf8"
+
 # use this to disable email delivery
 MAILER_DSN=null://localhost
 # use this to configure a traditional SMTP server
@@ -22,3 +25,4 @@ CDN_URL=https://cdn.veaf.org/website/dev
 REDIS_URL=redis://redis
 
 APP_REGISTRATION_DISABLED=0
+

--- a/CHANGELOG_389.md
+++ b/CHANGELOG_389.md
@@ -1,0 +1,5 @@
+- ADDED DCS Bot statistics import command (`app:dcsbot:import`) to synchronize data into Perun database
+- ADDED DcsBotImportService for fetching and transforming statistics from external DCS Bot database
+- ADDED DcsBotSyncState entity to track import progress per server
+- ADDED DcsBotStatistic DTO for mapping DCS Bot database records
+- ADDED Doctrine connection configuration for DCS Bot database

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,12 +1,18 @@
 doctrine:
     dbal:
-        url: '%env(resolve:DATABASE_PERUN_URL)%'
-
-        # IMPORTANT: You MUST configure your server version,
-        # either here or in the DATABASE_URL env var (see .env file)
-        #server_version: '13'
-        mapping_types:
-            enum: string
+        default_connection: perun
+        connections:
+            perun:
+                url: '%env(resolve:DATABASE_PERUN_URL)%'
+                # IMPORTANT: You MUST configure your server version,
+                # either here or in the DATABASE_URL env var (see .env file)
+                #server_version: '13'
+                mapping_types:
+                    enum: string
+            dcsbot:
+                url: '%env(resolve:DATABASE_DCSBOT_URL)%'
+                driver: 'pdo_pgsql'
+                charset: utf8
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -81,3 +81,7 @@ services:
     Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler:
         arguments:
             - '@snc_redis.session'
+
+    App\Perun\Service\DcsBotImportService:
+        arguments:
+            $dcsBotConnection: '@doctrine.dbal.dcsbot_connection'

--- a/migrations/Version20251224103214.php
+++ b/migrations/Version20251224103214.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251224103214 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE dcsbot_sync_state (server_id VARCHAR(50) NOT NULL, last_sync_at DATETIME NOT NULL, records_imported INT DEFAULT 0 NOT NULL, PRIMARY KEY(server_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE module RENAME INDEX name_idx TO UNIQ_C2426285E237E06');
+        $this->addSql('ALTER TABLE module RENAME INDEX code_idx TO UNIQ_C24262877153098');
+        $this->addSql('ALTER TABLE module_role RENAME INDEX name_idx TO UNIQ_ED55CF665E237E06');
+        $this->addSql('ALTER TABLE module_role RENAME INDEX code_idx TO UNIQ_ED55CF6677153098');
+        $this->addSql('ALTER TABLE module_system RENAME INDEX code_idx TO UNIQ_634E51A477153098');
+        $this->addSql('ALTER TABLE module_system RENAME INDEX name_idx TO UNIQ_634E51A45E237E06');
+        $this->addSql('ALTER TABLE variant RENAME INDEX code_idx TO UNIQ_F143BFAD77153098');
+        $this->addSql('ALTER TABLE variant RENAME INDEX name_idx TO UNIQ_F143BFAD5E237E06');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE dcsbot_sync_state');
+        $this->addSql('ALTER TABLE module RENAME INDEX uniq_c24262877153098 TO code_idx');
+        $this->addSql('ALTER TABLE module RENAME INDEX uniq_c2426285e237e06 TO name_idx');
+        $this->addSql('ALTER TABLE module_role RENAME INDEX uniq_ed55cf665e237e06 TO name_idx');
+        $this->addSql('ALTER TABLE module_role RENAME INDEX uniq_ed55cf6677153098 TO code_idx');
+        $this->addSql('ALTER TABLE module_system RENAME INDEX uniq_634e51a477153098 TO code_idx');
+        $this->addSql('ALTER TABLE module_system RENAME INDEX uniq_634e51a45e237e06 TO name_idx');
+        $this->addSql('ALTER TABLE variant RENAME INDEX uniq_f143bfad5e237e06 TO name_idx');
+        $this->addSql('ALTER TABLE variant RENAME INDEX uniq_f143bfad77153098 TO code_idx');
+    }
+}

--- a/src/Command/DcsBotImportCommand.php
+++ b/src/Command/DcsBotImportCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Command;
+
+use App\Perun\Service\DcsBotImportService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * Command to import statistics from DCS Bot database into Perun.
+ */
+class DcsBotImportCommand extends Command
+{
+    protected static $defaultName = 'app:dcsbot:import';
+    protected static $defaultDescription = 'Import statistics from DCS Bot database';
+
+    private DcsBotImportService $importService;
+
+    public function __construct(DcsBotImportService $importService)
+    {
+        parent::__construct();
+        $this->importService = $importService;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription(self::$defaultDescription)
+            ->addArgument(
+                'server',
+                InputArgument::OPTIONAL,
+                'Server identifier for tracking sync state',
+                'default'
+            )
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Run without persisting changes'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $chrono = new Stopwatch();
+
+        $chrono->start('import');
+
+        $serverId = $input->getArgument('server');
+        $dryRun = $input->getOption('dry-run');
+
+        if ($dryRun) {
+            $io->note('Dry-run mode enabled - no changes will be persisted');
+        }
+
+        try {
+            $imported = $this->importService->import($serverId, $output, $dryRun);
+        } catch (\Exception $e) {
+            $io->error(sprintf('Import failed: %s', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $chrono->stop('import');
+
+        $io->success(sprintf(
+            'Import completed: %d records in %.2f seconds',
+            $imported,
+            $chrono->getEvent('import')->getDuration() / 1000
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/DcsBotSyncState.php
+++ b/src/Entity/DcsBotSyncState.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Tracks the last synchronization state for DCS Bot statistics import.
+ *
+ * @ORM\Table(name="dcsbot_sync_state")
+ *
+ * @ORM\Entity
+ */
+class DcsBotSyncState
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\Column(type="string", length=50)
+     */
+    private string $serverId;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    private \DateTime $lastSyncAt;
+
+    /**
+     * @ORM\Column(type="integer", options={"default": 0})
+     */
+    private int $recordsImported = 0;
+
+    public function getServerId(): string
+    {
+        return $this->serverId;
+    }
+
+    public function setServerId(string $serverId): self
+    {
+        $this->serverId = $serverId;
+
+        return $this;
+    }
+
+    public function getLastSyncAt(): \DateTime
+    {
+        return $this->lastSyncAt;
+    }
+
+    public function setLastSyncAt(\DateTime $lastSyncAt): self
+    {
+        $this->lastSyncAt = $lastSyncAt;
+
+        return $this;
+    }
+
+    public function getRecordsImported(): int
+    {
+        return $this->recordsImported;
+    }
+
+    public function setRecordsImported(int $recordsImported): self
+    {
+        $this->recordsImported = $recordsImported;
+
+        return $this;
+    }
+}

--- a/src/Perun/DTO/DcsBotStatistic.php
+++ b/src/Perun/DTO/DcsBotStatistic.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Perun\DTO;
+
+/**
+ * Data Transfer Object for DCS Bot statistics row.
+ */
+class DcsBotStatistic
+{
+    private int $missionId;
+    private string $playerUcid;
+    private string $slot;
+    private int $side = 0;
+    private int $kills = 0;
+    private int $pvp = 0;
+    private int $deaths = 0;
+    private int $ejections = 0;
+    private int $crashes = 0;
+    private int $teamkills = 0;
+    private int $killsPlanes = 0;
+    private int $killsHelicopters = 0;
+    private int $killsShips = 0;
+    private int $killsSams = 0;
+    private int $killsGround = 0;
+    private int $takeoffs = 0;
+    private int $landings = 0;
+    private \DateTime $hopOn;
+    private ?\DateTime $hopOff = null;
+
+    /**
+     * Creates a DcsBotStatistic from a database row.
+     */
+    public static function fromRow(array $row): self
+    {
+        $dto = new self();
+        $dto->missionId = (int) $row['mission_id'];
+        $dto->playerUcid = $row['player_ucid'];
+        $dto->slot = $row['slot'];
+        $dto->side = (int) ($row['side'] ?? 0);
+        $dto->kills = (int) ($row['kills'] ?? 0);
+        $dto->pvp = (int) ($row['pvp'] ?? 0);
+        $dto->deaths = (int) ($row['deaths'] ?? 0);
+        $dto->ejections = (int) ($row['ejections'] ?? 0);
+        $dto->crashes = (int) ($row['crashes'] ?? 0);
+        $dto->teamkills = (int) ($row['teamkills'] ?? 0);
+        $dto->killsPlanes = (int) ($row['kills_planes'] ?? 0);
+        $dto->killsHelicopters = (int) ($row['kills_helicopters'] ?? 0);
+        $dto->killsShips = (int) ($row['kills_ships'] ?? 0);
+        $dto->killsSams = (int) ($row['kills_sams'] ?? 0);
+        $dto->killsGround = (int) ($row['kills_ground'] ?? 0);
+        $dto->takeoffs = (int) ($row['takeoffs'] ?? 0);
+        $dto->landings = (int) ($row['landings'] ?? 0);
+
+        $dto->hopOn = new \DateTime($row['hop_on']);
+        $dto->hopOff = null !== $row['hop_off'] ? new \DateTime($row['hop_off']) : null;
+
+        return $dto;
+    }
+
+    /**
+     * Calculates session duration in seconds.
+     */
+    public function getSessionDuration(): int
+    {
+        if (null === $this->hopOff) {
+            return 0;
+        }
+
+        return $this->hopOff->getTimestamp() - $this->hopOn->getTimestamp();
+    }
+
+    public function getMissionId(): int
+    {
+        return $this->missionId;
+    }
+
+    public function getPlayerUcid(): string
+    {
+        return $this->playerUcid;
+    }
+
+    public function getSlot(): string
+    {
+        return $this->slot;
+    }
+
+    public function getSide(): int
+    {
+        return $this->side;
+    }
+
+    public function getKills(): int
+    {
+        return $this->kills;
+    }
+
+    public function getPvp(): int
+    {
+        return $this->pvp;
+    }
+
+    public function getDeaths(): int
+    {
+        return $this->deaths;
+    }
+
+    public function getEjections(): int
+    {
+        return $this->ejections;
+    }
+
+    public function getCrashes(): int
+    {
+        return $this->crashes;
+    }
+
+    public function getTeamkills(): int
+    {
+        return $this->teamkills;
+    }
+
+    public function getKillsPlanes(): int
+    {
+        return $this->killsPlanes;
+    }
+
+    public function getKillsHelicopters(): int
+    {
+        return $this->killsHelicopters;
+    }
+
+    public function getKillsShips(): int
+    {
+        return $this->killsShips;
+    }
+
+    public function getKillsSams(): int
+    {
+        return $this->killsSams;
+    }
+
+    public function getKillsGround(): int
+    {
+        return $this->killsGround;
+    }
+
+    public function getTakeoffs(): int
+    {
+        return $this->takeoffs;
+    }
+
+    public function getLandings(): int
+    {
+        return $this->landings;
+    }
+
+    public function getHopOn(): \DateTime
+    {
+        return $this->hopOn;
+    }
+
+    public function getHopOff(): ?\DateTime
+    {
+        return $this->hopOff;
+    }
+}

--- a/src/Perun/Entity/LogStat.php
+++ b/src/Perun/Entity/LogStat.php
@@ -178,6 +178,8 @@ class LogStat
     private int $otherTakeoffs = 0;
 
     /**
+     * Session duration in minutes.
+     *
      * @ORM\Column(type="integer", name="ps_time", options={"unsigned"=true, "default": 0})
      */
     private int $time = 0;
@@ -388,5 +390,201 @@ class LogStat
     public function getTotalLandings(): int
     {
         return $this->farpLandings + $this->shipLandings + $this->otherLandings + $this->airfieldLandings;
+    }
+
+    public function setType(?DataType $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function setMasterSlot(int $masterSlot): self
+    {
+        $this->masterSlot = $masterSlot;
+
+        return $this;
+    }
+
+    public function setSeat(int $seat): self
+    {
+        $this->seat = $seat;
+
+        return $this;
+    }
+
+    public function setKillsX(int $killsX): self
+    {
+        $this->killsX = $killsX;
+
+        return $this;
+    }
+
+    public function setPvp(int $pvp): self
+    {
+        $this->pvp = $pvp;
+
+        return $this;
+    }
+
+    public function setDeaths(int $deaths): self
+    {
+        $this->deaths = $deaths;
+
+        return $this;
+    }
+
+    public function setEjections(int $ejections): self
+    {
+        $this->ejections = $ejections;
+
+        return $this;
+    }
+
+    public function setCrashes(int $crashes): self
+    {
+        $this->crashes = $crashes;
+
+        return $this;
+    }
+
+    public function setTeamKills(int $teamKills): self
+    {
+        $this->teamKills = $teamKills;
+
+        return $this;
+    }
+
+    public function setKillsPlanes(int $killsPlanes): self
+    {
+        $this->killsPlanes = $killsPlanes;
+
+        return $this;
+    }
+
+    public function setKillsHelicopters(int $killsHelicopters): self
+    {
+        $this->killsHelicopters = $killsHelicopters;
+
+        return $this;
+    }
+
+    public function setKillsAirDefense(int $killsAirDefense): self
+    {
+        $this->killsAirDefense = $killsAirDefense;
+
+        return $this;
+    }
+
+    public function setKillsArmor(int $killsArmor): self
+    {
+        $this->killsArmor = $killsArmor;
+
+        return $this;
+    }
+
+    public function setKillsUnarmed(int $killsUnarmed): self
+    {
+        $this->killsUnarmed = $killsUnarmed;
+
+        return $this;
+    }
+
+    public function setKillsInfantry(int $killsInfantry): self
+    {
+        $this->killsInfantry = $killsInfantry;
+
+        return $this;
+    }
+
+    public function setKillsShips(int $killsShips): self
+    {
+        $this->killsShips = $killsShips;
+
+        return $this;
+    }
+
+    public function setKillsFortification(int $killsFortification): self
+    {
+        $this->killsFortification = $killsFortification;
+
+        return $this;
+    }
+
+    public function setKillsArtillery(int $killsArtillery): self
+    {
+        $this->killsArtillery = $killsArtillery;
+
+        return $this;
+    }
+
+    public function setKillsOther(int $killsOther): self
+    {
+        $this->killsOther = $killsOther;
+
+        return $this;
+    }
+
+    public function setAirfieldTakeoffs(int $airfieldTakeoffs): self
+    {
+        $this->airfieldTakeoffs = $airfieldTakeoffs;
+
+        return $this;
+    }
+
+    public function setAirfieldLandings(int $airfieldLandings): self
+    {
+        $this->airfieldLandings = $airfieldLandings;
+
+        return $this;
+    }
+
+    public function setShipTakeoffs(int $shipTakeoffs): self
+    {
+        $this->shipTakeoffs = $shipTakeoffs;
+
+        return $this;
+    }
+
+    public function setShipLandings(int $shipLandings): self
+    {
+        $this->shipLandings = $shipLandings;
+
+        return $this;
+    }
+
+    public function setFarpTakeoffs(int $farpTakeoffs): self
+    {
+        $this->farpTakeoffs = $farpTakeoffs;
+
+        return $this;
+    }
+
+    public function setFarpLandings(int $farpLandings): self
+    {
+        $this->farpLandings = $farpLandings;
+
+        return $this;
+    }
+
+    public function setOtherTakeoffs(int $otherTakeoffs): self
+    {
+        $this->otherTakeoffs = $otherTakeoffs;
+
+        return $this;
+    }
+
+    public function setOtherLandings(int $otherLandings): self
+    {
+        $this->otherLandings = $otherLandings;
+
+        return $this;
+    }
+
+    public function setStatus(?string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
     }
 }

--- a/src/Perun/Service/DcsBotImportService.php
+++ b/src/Perun/Service/DcsBotImportService.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace App\Perun\Service;
+
+use App\Entity\DcsBotSyncState;
+use App\Perun\DTO\DcsBotStatistic;
+use App\Perun\Entity\DataType;
+use App\Perun\Entity\LogStat;
+use App\Perun\Entity\Player;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Service for importing DCS Bot statistics into Perun database.
+ */
+class DcsBotImportService
+{
+    private const BATCH_SIZE = 100;
+
+    private EntityManagerInterface $entityManager;
+    private Connection $dcsBotConnection;
+    private LoggerInterface $logger;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        Connection $dcsBotConnection,
+        LoggerInterface $logger,
+    ) {
+        $this->entityManager = $entityManager;
+        $this->dcsBotConnection = $dcsBotConnection;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Imports statistics from DCS Bot database.
+     */
+    public function import(string $serverId, OutputInterface $output, bool $dryRun = false): int
+    {
+        $lastSync = $this->getLastSyncTimestamp($serverId);
+
+        $output->writeln(sprintf(
+            'Importing DCS Bot stats for server <info>%s</info> since <comment>%s</comment>',
+            $serverId,
+            null !== $lastSync ? $lastSync->format('Y-m-d H:i:s') : 'beginning'
+        ));
+
+        $statistics = $this->fetchStatistics($lastSync);
+        $output->writeln(sprintf('Found <info>%d</info> records to import', count($statistics)));
+
+        if (0 === count($statistics)) {
+            return 0;
+        }
+
+        $imported = $this->importStatistics($statistics, $output, $dryRun);
+
+        if (!$dryRun) {
+            $this->updateSyncState($serverId, $imported);
+        }
+
+        $output->writeln(sprintf('<info>%d</info> records imported', $imported));
+
+        return $imported;
+    }
+
+    /**
+     * Fetches statistics from DCS Bot database.
+     *
+     * @return DcsBotStatistic[]
+     */
+    private function fetchStatistics(?\DateTime $since): array
+    {
+        $sql = 'SELECT * FROM statistics WHERE hop_off IS NOT NULL';
+        $params = [];
+        $types = [];
+
+        if (null !== $since) {
+            $sql .= ' AND hop_off > :since';
+            $params['since'] = $since->format('Y-m-d H:i:s');
+        }
+
+        $sql .= ' ORDER BY hop_off ASC';
+
+        $result = $this->dcsBotConnection->executeQuery($sql, $params, $types);
+
+        $statistics = [];
+        while ($row = $result->fetchAssociative()) {
+            $statistics[] = DcsBotStatistic::fromRow($row);
+        }
+
+        return $statistics;
+    }
+
+    /**
+     * Imports statistics into Perun database.
+     *
+     * @param DcsBotStatistic[] $statistics
+     */
+    private function importStatistics(array $statistics, OutputInterface $output, bool $dryRun): int
+    {
+        $playerCache = [];  // ucid => Player
+        $typeCache = [];    // slot => DataType
+        $imported = 0;
+
+        foreach ($statistics as $stat) {
+            // Find or create Perun Player
+            $player = $this->findOrCreatePlayer($stat->getPlayerUcid(), $playerCache, $dryRun);
+
+            // Find or create DataType
+            $type = $this->findOrCreateDataType($stat->getSlot(), $typeCache, $dryRun);
+
+            // Create LogStat
+            $logStat = $this->createLogStat($stat, $player, $type);
+
+            if (!$dryRun) {
+                $this->entityManager->persist($logStat);
+            }
+
+            ++$imported;
+
+            // Batch flush
+            if (!$dryRun && 0 === $imported % self::BATCH_SIZE) {
+                $this->entityManager->flush();
+                $this->entityManager->clear(LogStat::class);
+                $output->writeln(sprintf('  Flushed batch: %d records', $imported));
+            }
+        }
+
+        // Final flush
+        if (!$dryRun) {
+            $this->entityManager->flush();
+        }
+
+        return $imported;
+    }
+
+    /**
+     * Finds or creates a Perun Player by UCID.
+     *
+     * @param array<string, Player> $cache
+     */
+    private function findOrCreatePlayer(string $ucid, array &$cache, bool $dryRun): Player
+    {
+        if (isset($cache[$ucid])) {
+            return $cache[$ucid];
+        }
+
+        $player = $this->entityManager->getRepository(Player::class)
+            ->findOneBy(['ucid' => $ucid]);
+
+        if (null === $player) {
+            $player = new Player();
+            $player->setUcid($ucid);
+            $player->setUpdated(new \DateTime());
+
+            if (!$dryRun) {
+                $this->entityManager->persist($player);
+            }
+
+            $this->logger->info('Created new Perun player', ['ucid' => $ucid]);
+        }
+
+        $cache[$ucid] = $player;
+
+        return $player;
+    }
+
+    /**
+     * Finds or creates a DataType by slot name.
+     *
+     * @param array<string, DataType> $cache
+     */
+    private function findOrCreateDataType(string $slot, array &$cache, bool $dryRun): DataType
+    {
+        if (isset($cache[$slot])) {
+            return $cache[$slot];
+        }
+
+        $type = $this->entityManager->getRepository(DataType::class)
+            ->findOneBy(['name' => $slot]);
+
+        if (null === $type) {
+            $type = new DataType();
+            $type->setName($slot);
+            $type->setUpdated(new \DateTime());
+
+            if (!$dryRun) {
+                $this->entityManager->persist($type);
+            }
+
+            $this->logger->info('Created new DataType', ['slot' => $slot]);
+        }
+
+        $cache[$slot] = $type;
+
+        return $type;
+    }
+
+    /**
+     * Creates a LogStat entity from DCS Bot statistic.
+     */
+    private function createLogStat(
+        DcsBotStatistic $stat,
+        Player $player,
+        DataType $type,
+    ): LogStat {
+        $logStat = new LogStat();
+        $logStat->setPlayer($player);
+        $logStat->setType($type);
+        $logStat->setMission(null);  // No mission link as per requirements
+        $logStat->setDatetime($stat->getHopOff());
+        $logStat->setTime((int) ceil($stat->getSessionDuration() / 60)); // Convert seconds to minutes (rounded up)
+
+        // Direct mappings
+        $logStat->setKillsX($stat->getKills());
+        $logStat->setPvp($stat->getPvp());
+        $logStat->setDeaths($stat->getDeaths());
+        $logStat->setEjections($stat->getEjections());
+        $logStat->setCrashes($stat->getCrashes());
+        $logStat->setTeamKills($stat->getTeamkills());
+        $logStat->setKillsPlanes($stat->getKillsPlanes());
+        $logStat->setKillsHelicopters($stat->getKillsHelicopters());
+        $logStat->setKillsShips($stat->getKillsShips());
+
+        // Field mappings with name changes
+        $logStat->setKillsAirDefense($stat->getKillsSams());
+        $logStat->setKillsArmor($stat->getKillsGround());
+
+        // Aggregate takeoffs/landings to "other" category
+        $logStat->setOtherTakeoffs($stat->getTakeoffs());
+        $logStat->setOtherLandings($stat->getLandings());
+
+        // Leave other fields at default 0
+        $logStat->setStatus(null);
+
+        return $logStat;
+    }
+
+    /**
+     * Gets the last sync timestamp for a server.
+     */
+    private function getLastSyncTimestamp(string $serverId): ?\DateTime
+    {
+        $state = $this->entityManager->getRepository(DcsBotSyncState::class)
+            ->find($serverId);
+
+        return null !== $state ? $state->getLastSyncAt() : null;
+    }
+
+    /**
+     * Updates the sync state after import.
+     */
+    private function updateSyncState(string $serverId, int $recordsImported): void
+    {
+        $state = $this->entityManager->getRepository(DcsBotSyncState::class)
+            ->find($serverId);
+
+        if (null === $state) {
+            $state = new DcsBotSyncState();
+            $state->setServerId($serverId);
+            $this->entityManager->persist($state);
+        }
+
+        $state->setLastSyncAt(new \DateTime());
+        $state->setRecordsImported($state->getRecordsImported() + $recordsImported);
+
+        $this->entityManager->flush();
+    }
+}

--- a/tests/Unit/Perun/DTO/DcsBotStatisticTest.php
+++ b/tests/Unit/Perun/DTO/DcsBotStatisticTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Tests\Unit\Perun\DTO;
+
+use App\Perun\DTO\DcsBotStatistic;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for DcsBotStatistic DTO.
+ */
+class DcsBotStatisticTest extends TestCase
+{
+    public function testFromRowCreatesValidDto(): void
+    {
+        $row = [
+            'mission_id' => 42,
+            'player_ucid' => 'abc123def456',
+            'slot' => 'FA-18C_hornet',
+            'side' => 2,
+            'kills' => 5,
+            'pvp' => 2,
+            'deaths' => 1,
+            'ejections' => 0,
+            'crashes' => 1,
+            'teamkills' => 0,
+            'kills_planes' => 3,
+            'kills_helicopters' => 1,
+            'kills_ships' => 0,
+            'kills_sams' => 1,
+            'kills_ground' => 2,
+            'takeoffs' => 3,
+            'landings' => 2,
+            'hop_on' => '2024-12-24 10:00:00',
+            'hop_off' => '2024-12-24 11:30:00',
+        ];
+
+        $dto = DcsBotStatistic::fromRow($row);
+
+        $this->assertEquals(42, $dto->getMissionId());
+        $this->assertEquals('abc123def456', $dto->getPlayerUcid());
+        $this->assertEquals('FA-18C_hornet', $dto->getSlot());
+        $this->assertEquals(2, $dto->getSide());
+        $this->assertEquals(5, $dto->getKills());
+        $this->assertEquals(2, $dto->getPvp());
+        $this->assertEquals(1, $dto->getDeaths());
+        $this->assertEquals(0, $dto->getEjections());
+        $this->assertEquals(1, $dto->getCrashes());
+        $this->assertEquals(0, $dto->getTeamkills());
+        $this->assertEquals(3, $dto->getKillsPlanes());
+        $this->assertEquals(1, $dto->getKillsHelicopters());
+        $this->assertEquals(0, $dto->getKillsShips());
+        $this->assertEquals(1, $dto->getKillsSams());
+        $this->assertEquals(2, $dto->getKillsGround());
+        $this->assertEquals(3, $dto->getTakeoffs());
+        $this->assertEquals(2, $dto->getLandings());
+    }
+
+    public function testFromRowHandlesMissingOptionalFields(): void
+    {
+        $row = [
+            'mission_id' => 1,
+            'player_ucid' => 'ucid123',
+            'slot' => 'A-10C_2',
+            'hop_on' => '2024-12-24 10:00:00',
+            'hop_off' => null,
+        ];
+
+        $dto = DcsBotStatistic::fromRow($row);
+
+        $this->assertEquals(0, $dto->getSide());
+        $this->assertEquals(0, $dto->getKills());
+        $this->assertEquals(0, $dto->getPvp());
+        $this->assertEquals(0, $dto->getDeaths());
+        $this->assertEquals(0, $dto->getEjections());
+        $this->assertEquals(0, $dto->getCrashes());
+        $this->assertEquals(0, $dto->getTeamkills());
+        $this->assertNull($dto->getHopOff());
+    }
+
+    public function testGetSessionDurationReturnsCorrectSeconds(): void
+    {
+        $row = [
+            'mission_id' => 1,
+            'player_ucid' => 'ucid123',
+            'slot' => 'A-10C_2',
+            'hop_on' => '2024-12-24 10:00:00',
+            'hop_off' => '2024-12-24 11:30:00', // 1h30 = 5400 seconds
+        ];
+
+        $dto = DcsBotStatistic::fromRow($row);
+
+        $this->assertEquals(5400, $dto->getSessionDuration());
+    }
+
+    public function testGetSessionDurationReturnsZeroForNullHopOff(): void
+    {
+        $row = [
+            'mission_id' => 1,
+            'player_ucid' => 'ucid123',
+            'slot' => 'A-10C_2',
+            'hop_on' => '2024-12-24 10:00:00',
+            'hop_off' => null,
+        ];
+
+        $dto = DcsBotStatistic::fromRow($row);
+
+        $this->assertEquals(0, $dto->getSessionDuration());
+    }
+
+    public function testGetSessionDurationReturnsZeroForSameHopOnAndHopOff(): void
+    {
+        $row = [
+            'mission_id' => 1,
+            'player_ucid' => 'ucid123',
+            'slot' => 'A-10C_2',
+            'hop_on' => '2024-12-24 10:00:00',
+            'hop_off' => '2024-12-24 10:00:00',
+        ];
+
+        $dto = DcsBotStatistic::fromRow($row);
+
+        $this->assertEquals(0, $dto->getSessionDuration());
+    }
+
+    public function testHopOnAndHopOffAreDateTimeObjects(): void
+    {
+        $row = [
+            'mission_id' => 1,
+            'player_ucid' => 'ucid123',
+            'slot' => 'A-10C_2',
+            'hop_on' => '2024-12-24 10:00:00',
+            'hop_off' => '2024-12-24 11:30:00',
+        ];
+
+        $dto = DcsBotStatistic::fromRow($row);
+
+        $this->assertInstanceOf(\DateTime::class, $dto->getHopOn());
+        $this->assertInstanceOf(\DateTime::class, $dto->getHopOff());
+        $this->assertEquals('2024-12-24 10:00:00', $dto->getHopOn()->format('Y-m-d H:i:s'));
+        $this->assertEquals('2024-12-24 11:30:00', $dto->getHopOff()->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @dataProvider sessionDurationDataProvider
+     */
+    public function testGetSessionDurationWithVariousDurations(
+        string $hopOn,
+        string $hopOff,
+        int $expectedSeconds
+    ): void {
+        $row = [
+            'mission_id' => 1,
+            'player_ucid' => 'ucid123',
+            'slot' => 'A-10C_2',
+            'hop_on' => $hopOn,
+            'hop_off' => $hopOff,
+        ];
+
+        $dto = DcsBotStatistic::fromRow($row);
+
+        $this->assertEquals($expectedSeconds, $dto->getSessionDuration());
+    }
+
+    public function sessionDurationDataProvider(): array
+    {
+        return [
+            'one minute' => ['2024-12-24 10:00:00', '2024-12-24 10:01:00', 60],
+            'one hour' => ['2024-12-24 10:00:00', '2024-12-24 11:00:00', 3600],
+            'two hours thirty minutes' => ['2024-12-24 10:00:00', '2024-12-24 12:30:00', 9000],
+            'crossing midnight' => ['2024-12-24 23:00:00', '2024-12-25 01:00:00', 7200],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Import DCS Bot player statistics into the Perun database via a new service, console command, and dedicated sync state tracking, using a separate Doctrine DBAL connection.

New Features:
- Introduce a DcsBotImportService to pull statistics from an external DCS Bot database and persist them as LogStat records and related entities.
- Add a Symfony console command `app:dcsbot:import` to run the DCS Bot statistics import with optional dry-run mode.
- Add a DcsBotStatistic DTO to map raw DCS Bot statistics rows into a structured object model.
- Add a DcsBotSyncState entity and migration to track per-server import progress and counts in the Perun database.

Enhancements:
- Extend LogStat with setter methods and document the session duration field to support programmatic population from imported statistics.
- Configure Doctrine with an additional `dcsbot` DBAL connection and wire it into the new import service.

Documentation:
- Add a changelog entry describing the new DCS Bot statistics import functionality and configuration.

Tests:
- Add unit tests for DcsBotStatistic to validate row mapping and session duration calculations across various scenarios.