### PR TITLE
Feature/408 dont display players count when server is paused or shutdown

### DIFF
--- a/CHANGELOG_408.md
+++ b/CHANGELOG_408.md
@@ -1,0 +1,3 @@
+- UPDATED Hide player count on server list when server is not running (Paused/Shutdown)
+- UPDATED Hide players section on server detail page when server is not running
+- FIXED Replace underscores with spaces in mission and module names for better readability

--- a/templates/dcsbot/server.html.twig
+++ b/templates/dcsbot/server.html.twig
@@ -193,7 +193,7 @@
         </div>
         {% endif %}
 
-        {% if server.players and server.players|length > 0 %}
+        {% if server.status == 'Running' and server.players and server.players|length > 0 %}
         <div class="row mb-3 ml-1 mr-1">
             <div class="col-12">
                 <h2><i class="fa fa-users"></i> Joueurs en ligne ({{ server.players|length }})</h2>

--- a/templates/dcsbot/server.html.twig
+++ b/templates/dcsbot/server.html.twig
@@ -86,7 +86,7 @@
                         <table class="table table-sm mb-0">
                             <tr>
                                 <th><i class="fa fa-file-alt"></i> Nom</th>
-                                <td>{{ server.mission.name }}</td>
+                                <td>{{ server.mission.name|replace({'_': ' '}) }}</td>
                             </tr>
                             <tr>
                                 <th><i class="fa fa-map"></i> Théâtre</th>
@@ -478,7 +478,7 @@
                             <tbody>
                             {% for mission in attendance.topMissions %}
                                 <tr>
-                                    <td>{{ mission.missionName }}</td>
+                                    <td>{{ mission.missionName|replace({'_': ' '}) }}</td>
                                     <td class="text-right">{{ mission.playtimeHours|round(1) }}h</td>
                                 </tr>
                             {% endfor %}
@@ -500,7 +500,7 @@
                             <tbody>
                             {% for module in attendance.topModules %}
                                 <tr>
-                                    <td>{{ module.module }}</td>
+                                    <td>{{ module.module|replace({'_': ' '}) }}</td>
                                     <td class="text-right">{{ module.playtimeHours|round(1) }}h</td>
                                 </tr>
                             {% endfor %}

--- a/templates/dcsbot/server.html.twig
+++ b/templates/dcsbot/server.html.twig
@@ -193,7 +193,7 @@
         </div>
         {% endif %}
 
-        {% if server.status == 'Running' and server.players and server.players|length > 0 %}
+        {% if server.status == 'Running' and server.players|length > 0 %}
         <div class="row mb-3 ml-1 mr-1">
             <div class="col-12">
                 <h2><i class="fa fa-users"></i> Joueurs en ligne ({{ server.players|length }})</h2>

--- a/templates/dcsbot/stats.html.twig
+++ b/templates/dcsbot/stats.html.twig
@@ -44,15 +44,7 @@
                             <td>{{ server.mission ? server.mission.theatre : '-' }}</td>
                             <td>{{ server.mission ? server.mission.name|replace({'_': ' '}) : '-' }}</td>
                             <td>
-                                {% if server.status == 'Running' %}
-                                    {% if server.players %}
-                                        {{ server.players|length }}
-                                    {% else %}
-                                        0
-                                    {% endif %}
-                                {% else %}
-                                    -
-                                {% endif %}
+                                {{ server.status == 'Running' ? (server.players|default([])|length) : '-' }}
                             </td>
                             <td>
                                 {% if server.mission %}

--- a/templates/dcsbot/stats.html.twig
+++ b/templates/dcsbot/stats.html.twig
@@ -44,10 +44,14 @@
                             <td>{{ server.mission ? server.mission.theatre : '-' }}</td>
                             <td>{{ server.mission ? server.mission.name : '-' }}</td>
                             <td>
-                                {% if server.players %}
-                                    {{ server.players|length }}
+                                {% if server.status == 'Running' %}
+                                    {% if server.players %}
+                                        {{ server.players|length }}
+                                    {% else %}
+                                        0
+                                    {% endif %}
                                 {% else %}
-                                    0
+                                    -
                                 {% endif %}
                             </td>
                             <td>

--- a/templates/dcsbot/stats.html.twig
+++ b/templates/dcsbot/stats.html.twig
@@ -42,7 +42,7 @@
                                 {% endif %}
                             </td>
                             <td>{{ server.mission ? server.mission.theatre : '-' }}</td>
-                            <td>{{ server.mission ? server.mission.name : '-' }}</td>
+                            <td>{{ server.mission ? server.mission.name|replace({'_': ' '}) : '-' }}</td>
                             <td>
                                 {% if server.status == 'Running' %}
                                     {% if server.players %}


### PR DESCRIPTION
Closes #410 
Closes #408

## Summary by Sourcery

Hide player information when servers are not running and improve readability of mission and module names.

New Features:
- Hide player counts on the server stats list when the server is paused or shut down.

Bug Fixes:
- Replace underscores with spaces in mission, mission statistics, and module names to improve display readability.

Enhancements:
- Hide the detailed players section on the server detail page unless the server is running.

Documentation:
- Add a changelog entry documenting player visibility and naming display changes.