### PR TITLE
add ingame date/time information, add fuzzy sun position

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,6 +1,7 @@
 # Add a changelog
 
 Add a changelog named with this pattern "CHANGELOG_xxx.md" with xxx equals to the issue number (issue could be parsed from the current branch, ex: feature/123-my-description).
+Changelog must be written in English.
 Changelog should be very synthetic / summarized.
 Changelog line should always starts with "- NOUNCE" where NOUNCE is a word in the list: ADDED, UPDATED, FIXED, DEPRECATED, REMOVED.
 Changelog should not have a title.

--- a/CHANGELOG_412.md
+++ b/CHANGELOG_412.md
@@ -1,0 +1,3 @@
+- ADDED Mission time display on server list and server detail view
+- ADDED Colored sun position icon (day/night/dawn/dusk) based on theatre and mission time
+- ADDED Full mission date in tooltip on time hover

--- a/src/Service/SunPositionService.php
+++ b/src/Service/SunPositionService.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Service;
+
+class SunPositionService
+{
+    // Latitudes de référence par théâtre (point fixe DCS pour le calcul solaire)
+    private const THEATRE_LATITUDES = [
+        'caucasus' => 43.6,        // Région de Sochi
+        'persiangulf' => 25.0,     // Dubai
+        'syria' => 35.0,           // Méditerranée orientale
+        'nevada' => 36.0,          // Las Vegas (NTTR)
+        'normandy' => 49.0,        // Nord de la France
+        'sinai' => 30.0,           // Israël/Sinaï
+        'marianaislands' => 15.0,  // Saipan
+        'southatlantic' => -52.0,  // Falklands
+        'kola' => 69.0,            // Russie du Nord
+        'afghanistan' => 34.0,     // Afghanistan central
+    ];
+
+    private const DEFAULT_LATITUDE = 45.0;
+
+    // Seuils d'élévation solaire en degrés
+    private const ELEVATION_DAY = -6.0;      // Au-dessus = jour (crépuscule civil)
+    private const ELEVATION_TWILIGHT = -18.0; // Au-dessus = aube/crépuscule (crépuscule astronomique)
+
+    // Configuration des états
+    private const SUN_STATES = [
+        'day' => [
+            'icon' => 'fas fa-sun',
+            'color' => '#ffc107',
+            'tooltip' => 'Jour',
+        ],
+        'night' => [
+            'icon' => 'fas fa-moon',
+            'color' => '#6c757d',
+            'tooltip' => 'Nuit',
+        ],
+        'dawn' => [
+            'icon' => 'fas fa-cloud-sun',
+            'color' => '#fd7e14',
+            'tooltip' => 'Aube',
+        ],
+        'dusk' => [
+            'icon' => 'fas fa-cloud-sun',
+            'color' => '#fd7e14',
+            'tooltip' => 'Crépuscule',
+        ],
+    ];
+
+    public function getSunState(string $dateTime, string $theatre): array
+    {
+        $dt = $this->parseDateTime($dateTime);
+        if ($dt === null) {
+            return $this->getDefaultState();
+        }
+
+        $latitude = $this->getTheatreLatitude($theatre);
+        $elevation = $this->calculateSunElevation($dt, $latitude);
+        $state = $this->determineSunState($elevation, $dt);
+
+        return array_merge(
+            ['state' => $state],
+            self::SUN_STATES[$state]
+        );
+    }
+
+    public function getTheatreLatitude(string $theatre): float
+    {
+        $normalizedTheatre = strtolower(str_replace([' ', '_', '-'], '', $theatre));
+
+        return self::THEATRE_LATITUDES[$normalizedTheatre] ?? self::DEFAULT_LATITUDE;
+    }
+
+    public function calculateSunElevation(\DateTime $dateTime, float $latitude): float
+    {
+        // Jour de l'année (1-365)
+        $dayOfYear = (int) $dateTime->format('z') + 1;
+
+        // Heure décimale (0-24)
+        $hour = (int) $dateTime->format('H');
+        $minute = (int) $dateTime->format('i');
+        $decimalHour = $hour + $minute / 60.0;
+
+        // Déclinaison solaire (formule simplifiée)
+        // d = -23.45 * cos(360/365 * (N + 10))
+        $declination = -23.45 * cos(deg2rad(360.0 / 365.0 * ($dayOfYear + 10)));
+
+        // Angle horaire en degrés
+        // H = (heure - 12) * 15
+        $hourAngle = ($decimalHour - 12.0) * 15.0;
+
+        // Élévation solaire
+        // sin(alt) = sin(lat) * sin(d) + cos(lat) * cos(d) * cos(H)
+        $latRad = deg2rad($latitude);
+        $declRad = deg2rad($declination);
+        $hourAngleRad = deg2rad($hourAngle);
+
+        $sinElevation = sin($latRad) * sin($declRad)
+            + cos($latRad) * cos($declRad) * cos($hourAngleRad);
+
+        // Clamp pour éviter les erreurs de domaine asin
+        $sinElevation = max(-1.0, min(1.0, $sinElevation));
+
+        return rad2deg(asin($sinElevation));
+    }
+
+    private function determineSunState(float $elevation, \DateTime $dateTime): string
+    {
+        $hour = (int) $dateTime->format('H');
+
+        if ($elevation > self::ELEVATION_DAY) {
+            return 'day';
+        }
+
+        if ($elevation > self::ELEVATION_TWILIGHT) {
+            // Aube le matin, crépuscule l'après-midi
+            return $hour < 12 ? 'dawn' : 'dusk';
+        }
+
+        return 'night';
+    }
+
+    private function parseDateTime(string $dateTime): ?\DateTime
+    {
+        // Format attendu: "YYYY-MM-DD HH:MM:SS"
+        $dt = \DateTime::createFromFormat('Y-m-d H:i:s', $dateTime);
+        if ($dt !== false) {
+            return $dt;
+        }
+
+        // Essayer d'autres formats courants
+        $dt = \DateTime::createFromFormat('Y-m-d H:i', $dateTime);
+        if ($dt !== false) {
+            return $dt;
+        }
+
+        return null;
+    }
+
+    private function getDefaultState(): array
+    {
+        return array_merge(
+            ['state' => 'day'],
+            self::SUN_STATES['day']
+        );
+    }
+}

--- a/src/Twig/SunPositionExtension.php
+++ b/src/Twig/SunPositionExtension.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Twig;
+
+use App\Service\SunPositionService;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+class SunPositionExtension extends AbstractExtension
+{
+    private SunPositionService $sunPositionService;
+
+    public function __construct(SunPositionService $sunPositionService)
+    {
+        $this->sunPositionService = $sunPositionService;
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('mission_time', [$this, 'formatMissionTime']),
+            new TwigFilter('mission_date', [$this, 'formatMissionDate']),
+        ];
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sun_state', [$this, 'getSunState']),
+        ];
+    }
+
+    /**
+     * Formate la date/heure de mission en heure seule (ex: "14:30")
+     */
+    public function formatMissionTime(?string $dateTime): string
+    {
+        if ($dateTime === null || $dateTime === '') {
+            return '-';
+        }
+
+        $dt = \DateTime::createFromFormat('Y-m-d H:i:s', $dateTime);
+        if ($dt === false) {
+            $dt = \DateTime::createFromFormat('Y-m-d H:i', $dateTime);
+        }
+
+        if ($dt === false) {
+            return '-';
+        }
+
+        return $dt->format('H:i');
+    }
+
+    /**
+     * Formate la date/heure de mission en date complète (ex: "7 août 2025")
+     */
+    public function formatMissionDate(?string $dateTime): string
+    {
+        if ($dateTime === null || $dateTime === '') {
+            return '-';
+        }
+
+        $dt = \DateTime::createFromFormat('Y-m-d H:i:s', $dateTime);
+        if ($dt === false) {
+            $dt = \DateTime::createFromFormat('Y-m-d H:i', $dateTime);
+        }
+
+        if ($dt === false) {
+            return '-';
+        }
+
+        $months = [
+            1 => 'janvier',
+            2 => 'février',
+            3 => 'mars',
+            4 => 'avril',
+            5 => 'mai',
+            6 => 'juin',
+            7 => 'juillet',
+            8 => 'août',
+            9 => 'septembre',
+            10 => 'octobre',
+            11 => 'novembre',
+            12 => 'décembre',
+        ];
+
+        $day = (int) $dt->format('j');
+        $month = $months[(int) $dt->format('n')];
+        $year = $dt->format('Y');
+
+        return sprintf('%d %s %s', $day, $month, $year);
+    }
+
+    /**
+     * Retourne l'état du soleil pour une date/heure et un théâtre donnés
+     *
+     * @return array{state: string, icon: string, color: string, tooltip: string}
+     */
+    public function getSunState(?string $dateTime, ?string $theatre): array
+    {
+        if ($dateTime === null || $dateTime === '' || $theatre === null || $theatre === '') {
+            return [
+                'state' => 'day',
+                'icon' => 'fas fa-sun',
+                'color' => '#ffc107',
+                'tooltip' => 'Jour',
+            ];
+        }
+
+        return $this->sunPositionService->getSunState($dateTime, $theatre);
+    }
+}

--- a/templates/dcsbot/server.html.twig
+++ b/templates/dcsbot/server.html.twig
@@ -92,6 +92,18 @@
                                 <th><i class="fa fa-map"></i> Théâtre</th>
                                 <td>{{ server.mission.theatre }}</td>
                             </tr>
+                            {% if server.mission.dateTime %}
+                            <tr>
+                                <th><i class="fa fa-sun"></i> Heure mission</th>
+                                <td>
+                                    {% set sun = sun_state(server.mission.dateTime, server.mission.theatre) %}
+                                    <span title="{{ server.mission.dateTime|mission_date }}">
+                                        {{ server.mission.dateTime|mission_time }}
+                                    </span>
+                                    <i class="{{ sun.icon }} ml-2" style="color: {{ sun.color }}" title="{{ sun.tooltip }}"></i>
+                                </td>
+                            </tr>
+                            {% endif %}
                             <tr>
                                 <th><i class="fa fa-clock"></i> Uptime</th>
                                 <td>{{ (server.mission.uptime / 60)|round }}min</td>

--- a/templates/dcsbot/stats.html.twig
+++ b/templates/dcsbot/stats.html.twig
@@ -22,6 +22,7 @@
                         <th><i class="fas fa-power-off mr-1"></i> Status</th>
                         <th><i class="fas fa-globe mr-1"></i> Theatre</th>
                         <th><i class="fas fa-fighter-jet mr-1"></i> Mission</th>
+                        <th><i class="fas fa-sun mr-1"></i> Heure</th>
                         <th><i class="fas fa-users mr-1"></i> Joueurs</th>
                         <th><i class="fas fa-clock mr-1"></i> Uptime</th>
                     </tr>
@@ -44,6 +45,17 @@
                             <td>{{ server.mission ? server.mission.theatre : '-' }}</td>
                             <td>{{ server.mission ? server.mission.name|replace({'_': ' '}) : '-' }}</td>
                             <td>
+                                {% if server.mission and server.mission.dateTime %}
+                                    {% set sun = sun_state(server.mission.dateTime, server.mission.theatre) %}
+                                    <i class="{{ sun.icon }}" style="color: {{ sun.color }}" title="{{ sun.tooltip }}"></i>
+                                    <span title="{{ server.mission.dateTime|mission_date }}">
+                                        {{ server.mission.dateTime|mission_time }}
+                                    </span>
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                            <td>
                                 {{ server.status == 'Running' ? (server.players|default([])|length) : '-' }}
                             </td>
                             <td>
@@ -56,7 +68,7 @@
                         </tr>
                     {% else %}
                         <tr>
-                            <td colspan="6">
+                            <td colspan="7">
                                 <i>Pas de serveurs disponibles</i>
                             </td>
                         </tr>

--- a/tests/Unit/Service/SunPositionServiceTest.php
+++ b/tests/Unit/Service/SunPositionServiceTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\SunPositionService;
+use PHPUnit\Framework\TestCase;
+
+class SunPositionServiceTest extends TestCase
+{
+    private SunPositionService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new SunPositionService();
+    }
+
+    /**
+     * @dataProvider theatreLatitudeProvider
+     */
+    public function testGetTheatreLatitudeReturnsCorrectValue(string $theatre, float $expectedLatitude): void
+    {
+        $latitude = $this->service->getTheatreLatitude($theatre);
+        $this->assertEqualsWithDelta($expectedLatitude, $latitude, 0.1);
+    }
+
+    public function theatreLatitudeProvider(): array
+    {
+        return [
+            'caucasus' => ['Caucasus', 43.6],
+            'persiangulf' => ['PersianGulf', 25.0],
+            'syria' => ['Syria', 35.0],
+            'nevada' => ['Nevada', 36.0],
+            'normandy' => ['Normandy', 49.0],
+            'sinai' => ['Sinai', 30.0],
+            'marianaislands' => ['MarianaIslands', 15.0],
+            'southatlantic' => ['SouthAtlantic', -52.0],
+            'kola' => ['Kola', 69.0],
+            'afghanistan' => ['Afghanistan', 34.0],
+        ];
+    }
+
+    public function testGetTheatreLatitudeIsCaseInsensitive(): void
+    {
+        $this->assertEqualsWithDelta(
+            $this->service->getTheatreLatitude('CAUCASUS'),
+            $this->service->getTheatreLatitude('caucasus'),
+            0.01
+        );
+
+        $this->assertEqualsWithDelta(
+            $this->service->getTheatreLatitude('PersianGulf'),
+            $this->service->getTheatreLatitude('persiangulf'),
+            0.01
+        );
+    }
+
+    public function testGetTheatreLatitudeHandlesVariations(): void
+    {
+        // With spaces
+        $this->assertEqualsWithDelta(25.0, $this->service->getTheatreLatitude('Persian Gulf'), 0.1);
+
+        // With underscores
+        $this->assertEqualsWithDelta(15.0, $this->service->getTheatreLatitude('Mariana_Islands'), 0.1);
+
+        // With dashes
+        $this->assertEqualsWithDelta(-52.0, $this->service->getTheatreLatitude('South-Atlantic'), 0.1);
+    }
+
+    public function testGetTheatreLatitudeReturnsDefaultForUnknown(): void
+    {
+        $latitude = $this->service->getTheatreLatitude('UnknownTheatre');
+        $this->assertEqualsWithDelta(45.0, $latitude, 0.1);
+    }
+
+    /**
+     * @dataProvider sunElevationProvider
+     */
+    public function testCalculateSunElevation(string $dateTime, float $latitude, float $minExpected, float $maxExpected): void
+    {
+        $dt = \DateTime::createFromFormat('Y-m-d H:i:s', $dateTime);
+        $elevation = $this->service->calculateSunElevation($dt, $latitude);
+
+        $this->assertGreaterThanOrEqual($minExpected, $elevation);
+        $this->assertLessThanOrEqual($maxExpected, $elevation);
+    }
+
+    public function sunElevationProvider(): array
+    {
+        return [
+            // Midi en été au Caucase - soleil haut
+            'caucasus_summer_noon' => ['2025-06-21 12:00:00', 43.6, 60.0, 75.0],
+            // Minuit en été au Caucase - soleil sous l'horizon
+            'caucasus_summer_midnight' => ['2025-06-21 00:00:00', 43.6, -70.0, -20.0],
+            // Midi en hiver au Caucase - soleil plus bas
+            'caucasus_winter_noon' => ['2025-12-21 12:00:00', 43.6, 15.0, 35.0],
+            // Midi à Dubai (plus au sud) - soleil plus haut
+            'dubai_summer_noon' => ['2025-06-21 12:00:00', 25.0, 80.0, 90.0],
+            // Midi aux Falklands (hémisphère sud, été en décembre)
+            'falklands_summer_noon' => ['2025-12-21 12:00:00', -52.0, 50.0, 70.0],
+        ];
+    }
+
+    /**
+     * @dataProvider sunStateProvider
+     */
+    public function testGetSunStateReturnsCorrectState(string $dateTime, string $theatre, string $expectedState): void
+    {
+        $result = $this->service->getSunState($dateTime, $theatre);
+
+        $this->assertArrayHasKey('state', $result);
+        $this->assertArrayHasKey('icon', $result);
+        $this->assertArrayHasKey('color', $result);
+        $this->assertArrayHasKey('tooltip', $result);
+        $this->assertEquals($expectedState, $result['state']);
+    }
+
+    public function sunStateProvider(): array
+    {
+        return [
+            // Cas clairs - jour
+            'caucasus_midday_summer' => ['2025-06-21 12:00:00', 'Caucasus', 'day'],
+            'caucasus_midday_winter' => ['2025-12-21 12:00:00', 'Caucasus', 'day'],
+            'dubai_midday' => ['2025-06-21 12:00:00', 'PersianGulf', 'day'],
+            'caucasus_morning' => ['2025-06-21 08:00:00', 'Caucasus', 'day'],
+            'caucasus_afternoon' => ['2025-06-21 16:00:00', 'Caucasus', 'day'],
+
+            // Cas clairs - nuit (minuit et heures très tardives/tôt)
+            'caucasus_midnight_winter' => ['2025-12-21 00:00:00', 'Caucasus', 'night'],
+            'caucasus_midnight_summer' => ['2025-06-21 00:00:00', 'Caucasus', 'night'],
+            'dubai_midnight' => ['2025-06-21 00:00:00', 'PersianGulf', 'night'],
+            'dubai_late_night' => ['2025-06-21 03:00:00', 'PersianGulf', 'night'],
+
+            // Aube (matin, élévation entre -18 et -6) - fenêtre très courte
+            'caucasus_dawn_summer' => ['2025-06-21 03:30:00', 'Caucasus', 'dawn'],
+            'dubai_dawn' => ['2025-06-21 04:30:00', 'PersianGulf', 'dawn'],
+
+            // Crépuscule (soir, élévation entre -18 et -6) - fenêtre très courte
+            'caucasus_dusk_summer' => ['2025-06-21 21:00:00', 'Caucasus', 'dusk'],
+            'dubai_dusk' => ['2025-06-21 20:00:00', 'PersianGulf', 'dusk'],
+        ];
+    }
+
+    public function testGetSunStateReturnsCorrectIcons(): void
+    {
+        $dayResult = $this->service->getSunState('2025-06-21 12:00:00', 'Caucasus');
+        $this->assertEquals('fas fa-sun', $dayResult['icon']);
+        $this->assertEquals('#ffc107', $dayResult['color']);
+        $this->assertEquals('Jour', $dayResult['tooltip']);
+
+        $nightResult = $this->service->getSunState('2025-06-21 00:00:00', 'Caucasus');
+        $this->assertEquals('fas fa-moon', $nightResult['icon']);
+        $this->assertEquals('#6c757d', $nightResult['color']);
+        $this->assertEquals('Nuit', $nightResult['tooltip']);
+
+        // Aube très tôt le matin (élévation entre -18 et -6)
+        $dawnResult = $this->service->getSunState('2025-06-21 03:30:00', 'Caucasus');
+        $this->assertEquals('fas fa-cloud-sun', $dawnResult['icon']);
+        $this->assertEquals('#fd7e14', $dawnResult['color']);
+        $this->assertEquals('Aube', $dawnResult['tooltip']);
+
+        // Crépuscule tard le soir
+        $duskResult = $this->service->getSunState('2025-06-21 21:00:00', 'Caucasus');
+        $this->assertEquals('fas fa-cloud-sun', $duskResult['icon']);
+        $this->assertEquals('#fd7e14', $duskResult['color']);
+        $this->assertEquals('Crépuscule', $duskResult['tooltip']);
+    }
+
+    public function testGetSunStateHandlesInvalidDateTime(): void
+    {
+        $result = $this->service->getSunState('invalid-date', 'Caucasus');
+
+        // Should return default (day) state
+        $this->assertEquals('day', $result['state']);
+    }
+
+    public function testGetSunStateHandlesAlternativeDateFormat(): void
+    {
+        // Format without seconds
+        $result = $this->service->getSunState('2025-06-21 12:00', 'Caucasus');
+        $this->assertEquals('day', $result['state']);
+    }
+
+    /**
+     * Test spécifique pour Kola (latitude extrême avec soleil de minuit)
+     */
+    public function testKolaMidnightSunInSummer(): void
+    {
+        // En été, à Kola (69°N), le soleil peut rester au-dessus de l'horizon à minuit
+        $result = $this->service->getSunState('2025-06-21 00:00:00', 'Kola');
+
+        // Le soleil de minuit signifie qu'il peut être jour ou aube même à minuit
+        $this->assertContains($result['state'], ['day', 'dawn', 'dusk']);
+    }
+
+    /**
+     * Test pour les Falklands (hémisphère sud)
+     */
+    public function testSouthAtlanticSeasons(): void
+    {
+        // Décembre = été dans l'hémisphère sud
+        $summerResult = $this->service->getSunState('2025-12-21 12:00:00', 'SouthAtlantic');
+        $this->assertEquals('day', $summerResult['state']);
+
+        // Juin = hiver dans l'hémisphère sud (jours courts mais toujours jour à midi)
+        $winterResult = $this->service->getSunState('2025-06-21 12:00:00', 'SouthAtlantic');
+        $this->assertEquals('day', $winterResult['state']);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Display mission date/time with contextual sun state indicators in DCS server stats and detail views, backed by a new sun position service, Twig extensions, and unit tests.

New Features:
- Show mission local time and full date tooltip in the servers list and server detail pages when mission date/time is available.
- Indicate day, night, dawn, or dusk with a color-coded sun icon derived from mission time and theatre location.
- Provide a Twig extension for formatting mission dates/times and exposing a sun state helper in templates.
- Introduce a SunPositionService that estimates sun elevation per theatre and maps it to semantic day/night/dawn/dusk states.

Documentation:
- Clarify internal changelog creation instructions, including language requirements and entry format.

Tests:
- Add comprehensive unit tests for SunPositionService latitude handling, sun elevation calculations, and sun state outputs, including edge cases like extreme latitudes and invalid dates.