### PR TITLE
fix wrong field type for vote entity

### DIFF
--- a/CHANGELOG_393.md
+++ b/CHANGELOG_393.md
@@ -1,0 +1,1 @@
+- FIXED Doctrine type mismatch in Vote entity by changing column type from integer to boolean

--- a/migrations/Version20251226131439.php
+++ b/migrations/Version20251226131439.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251226131439 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change event_vote.vote column type from INT to BOOLEAN to match PHP property type';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event_vote CHANGE vote vote TINYINT(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event_vote CHANGE vote vote INT DEFAULT NULL');
+    }
+}

--- a/src/Entity/Calendar/Vote.php
+++ b/src/Entity/Calendar/Vote.php
@@ -47,7 +47,7 @@ class Vote
     private ?Event $event;
 
     /**
-     * @ORM\Column(type="integer", nullable=true)
+     * @ORM\Column(type="boolean", nullable=true)
      */
     private ?bool $vote;
 


### PR DESCRIPTION
## Summary by Sourcery

Align the Vote entity field type with the database schema and document the fix.

Bug Fixes:
- Correct the Doctrine column mapping for the Vote entity by changing the vote field type from integer to boolean.

Build:
- Add a Doctrine migration to change the event_vote.vote column from INT to BOOLEAN and provide a down migration to revert the change.

Documentation:
- Update the changelog to note the fix for the Vote entity Doctrine type mismatch.