### PR TITLE
display missions names without ICAO section

### DIFF
--- a/CHANGELOG_418.md
+++ b/CHANGELOG_418.md
@@ -1,0 +1,1 @@
+- FIXED display missions names without ICAO section

--- a/src/Twig/ServerExtension.php
+++ b/src/Twig/ServerExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class ServerExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('strip_icao', [$this, 'stripIcao']),
+        ];
+    }
+
+    public function stripIcao(string $name): string
+    {
+        return preg_replace('/ ICAO\s+\S+$/', '', $name);
+    }
+}

--- a/templates/dcsbot/server.html.twig
+++ b/templates/dcsbot/server.html.twig
@@ -86,7 +86,7 @@
                         <table class="table table-sm mb-0">
                             <tr>
                                 <th><i class="fa fa-file-alt"></i> Nom</th>
-                                <td>{{ server.mission.name|replace({'_': ' '}) }}</td>
+                                <td title="{{ server.mission.name|replace({'_': ' '}) }}">{{ server.mission.name|replace({'_': ' '})|strip_icao }}</td>
                             </tr>
                             <tr>
                                 <th><i class="fa fa-map"></i> Théâtre</th>

--- a/templates/dcsbot/stats.html.twig
+++ b/templates/dcsbot/stats.html.twig
@@ -43,7 +43,7 @@
                                 {% endif %}
                             </td>
                             <td>{{ server.mission ? server.mission.theatre : '-' }}</td>
-                            <td>{{ server.mission ? server.mission.name|replace({'_': ' '}) : '-' }}</td>
+                            <td{% if server.mission %} title="{{ server.mission.name|replace({'_': ' '}) }}"{% endif %}>{{ server.mission ? server.mission.name|replace({'_': ' '})|strip_icao : '-' }}</td>
                             <td>
                                 {% if server.mission and server.mission.dateTime %}
                                     {% set sun = sun_state(server.mission.dateTime, server.mission.theatre) %}


### PR DESCRIPTION
## Summary by Sourcery

Strip ICAO suffixes from displayed mission names while keeping the full name available as a tooltip.

Bug Fixes:
- Hide ICAO suffix information from mission name columns in server and stats templates to match desired display format.

Enhancements:
- Introduce a reusable Twig filter to remove trailing ICAO segments from mission names.
- Document the behavior change for mission name display in the changelog.