### PR TITLE
Cloud density now displayed as /10 (tenths) instead of /8 (octa)

### DIFF
--- a/CHANGELOG_419.md
+++ b/CHANGELOG_419.md
@@ -1,0 +1,1 @@
+- FIX Cloud density now displayed as /10 (tenths) instead of /8 (octa) on server detail page

--- a/templates/dcsbot/server.html.twig
+++ b/templates/dcsbot/server.html.twig
@@ -184,7 +184,7 @@
                             </tr>
                             <tr>
                                 <th><i class="fa fa-th"></i> Densité</th>
-                                <td colspan="2">{{ server.weather.cloudsDensity }}/8</td>
+                                <td colspan="2">{{ server.weather.cloudsDensity }}/10</td>
                             </tr>
                             {% if server.weather.precipitation > 0 %}
                             <tr>


### PR DESCRIPTION
## Summary by Sourcery

Update cloud density display units on the server detail page and document the change in the changelog.

Bug Fixes:
- Correct cloud density unit display from eighths to tenths on the server detail page.

Documentation:
- Add changelog entry describing the corrected cloud density display.