### PR TITLE
fix connected players for shutdown servers

### DIFF
--- a/CHANGELOG_418.md
+++ b/CHANGELOG_418.md
@@ -1,1 +1,1 @@
-- FIXED display missions names without ICAO section
+- FIX display missions names without ICAO section

--- a/CHANGELOG_423.md
+++ b/CHANGELOG_423.md
@@ -1,0 +1,1 @@
+- FIX Header player count now only includes players from running servers (excludes paused and shutdown servers)

--- a/src/Service/DcsBotService.php
+++ b/src/Service/DcsBotService.php
@@ -53,7 +53,20 @@ class DcsBotService
 
     public function getActivePlayers(bool $forceRefresh = false): ?int
     {
-        return $this->getServerStats($forceRefresh)?->getActivePlayers();
+        $servers = $this->getServers($forceRefresh);
+
+        if (null === $servers) {
+            return null;
+        }
+
+        $count = 0;
+        foreach ($servers as $server) {
+            if ('Running' === $server->getStatus()) {
+                $count += count($server->getPlayers() ?? []);
+            }
+        }
+
+        return $count;
     }
 
     /**

--- a/tests/Unit/Service/DcsBotServiceTest.php
+++ b/tests/Unit/Service/DcsBotServiceTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\DcsBotService;
+use DcsServerBot\Api\InfoApi;
+use DcsServerBot\ApiException;
+use DcsServerBot\Model\PlayerEntry;
+use DcsServerBot\Model\ServerInfo;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class DcsBotServiceTest extends TestCase
+{
+    /** @var InfoApi&MockObject */
+    private InfoApi $infoApi;
+    private ArrayAdapter $cacheAdapter;
+    /** @var LoggerInterface&MockObject */
+    private LoggerInterface $logger;
+    private DcsBotService $service;
+
+    protected function setUp(): void
+    {
+        $this->infoApi = $this->createMock(InfoApi::class);
+        $this->cacheAdapter = new ArrayAdapter();
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->service = new DcsBotService(
+            $this->infoApi,
+            $this->cacheAdapter,
+            $this->logger,
+        );
+    }
+
+    public function testGetActivePlayersReturnsNullWhenApiUnavailable(): void
+    {
+        $this->infoApi
+            ->method('serversServerapiServersGet')
+            ->willThrowException(new ApiException('API down'));
+
+        $this->assertNull($this->service->getActivePlayers());
+    }
+
+    public function testGetActivePlayersCountsOnlyRunningServers(): void
+    {
+        $this->infoApi
+            ->method('serversServerapiServersGet')
+            ->willReturn([
+                $this->createServerInfo('Running', 3),
+                $this->createServerInfo('Paused', 2),
+                $this->createServerInfo('Shutdown', 0),
+            ]);
+
+        $this->assertSame(3, $this->service->getActivePlayers());
+    }
+
+    public function testGetActivePlayersReturnsZeroWhenNoRunningServers(): void
+    {
+        $this->infoApi
+            ->method('serversServerapiServersGet')
+            ->willReturn([
+                $this->createServerInfo('Paused', 5),
+            ]);
+
+        $this->assertSame(0, $this->service->getActivePlayers());
+    }
+
+    public function testGetActivePlayersSumsAcrossMultipleRunningServers(): void
+    {
+        $this->infoApi
+            ->method('serversServerapiServersGet')
+            ->willReturn([
+                $this->createServerInfo('Running', 2),
+                $this->createServerInfo('Running', 4),
+            ]);
+
+        $this->assertSame(6, $this->service->getActivePlayers());
+    }
+
+    public function testGetActivePlayersHandlesNullPlayersArray(): void
+    {
+        $server = new ServerInfo([
+            'name' => 'TestServer',
+            'status' => 'Running',
+            'address' => '1.2.3.4:10308',
+            'password' => '',
+        ]);
+
+        $this->infoApi
+            ->method('serversServerapiServersGet')
+            ->willReturn([$server]);
+
+        $this->assertSame(0, $this->service->getActivePlayers());
+    }
+
+    public function testGetActivePlayersReturnsZeroForEmptyServerList(): void
+    {
+        $this->infoApi
+            ->method('serversServerapiServersGet')
+            ->willReturn([]);
+
+        $this->assertSame(0, $this->service->getActivePlayers());
+    }
+
+    private function createServerInfo(string $status, int $playerCount): ServerInfo
+    {
+        $players = [];
+        for ($i = 0; $i < $playerCount; $i++) {
+            $players[] = new PlayerEntry([
+                'nick' => 'Player'.$i,
+                'side' => 'Blue',
+                'unit_type' => 'F-16C',
+                'callsign' => 'Viper'.$i,
+                'radios' => [],
+            ]);
+        }
+
+        return new ServerInfo([
+            'name' => 'TestServer-'.$status,
+            'status' => $status,
+            'address' => '1.2.3.4:10308',
+            'password' => '',
+            'players' => $players,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Update active player counting to aggregate players only from running servers and document the change in the changelog.

Bug Fixes:
- Ensure active player count excludes players from paused and shutdown servers and correctly reflects only running servers.

Documentation:
- Update 4.1.8 changelog entry wording and add 4.2.3 changelog note describing the corrected player count behavior.

Tests:
- Add unit tests covering active player counting across multiple servers, handling of non-running servers, null players arrays, empty server lists, and API unavailability.